### PR TITLE
Replace invalid characters in the file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Please use at your own risk. Take a backup of the dashboards before performing destructive operations.
 
+## Requirements
+
+- python 3
+- jq 1.6
+
 # Configuration
 Edit grafana.rc, and set the admin username, password, organization
 Then source it in the shell


### PR DESCRIPTION
First of all, thanks for the useful tool.

## Summary

The dump failed if the dashboard name contains "/" .

## Environments

- Ubuntu 18.04 LTS on WSL1

## Steps to reproduce

dashboard name: `cloudwatch/ec2`

```shell
./grafana-dash.py --dump
...
Traceback (most recent call last):
  File "./grafana-dash.py", line 171, in <module>
    sys.exit(main())
  File "./grafana-dash.py", line 168, in main
    return args.func(args)
  File "./grafana-dash.py", line 52, in dashboard_command
    dump_dashboard(dash['title'])
  File "./grafana-dash.py", line 103, in dump_dashboard
    with open(name, 'w') as fh:
FileNotFoundError: [Errno 2] No such file or directory: 'XX_cloudwatch/ec2.json'

```