### PR TITLE
Replace data source name in template

### DIFF
--- a/update-datasource.jq
+++ b/update-datasource.jq
@@ -6,7 +6,13 @@ walk(
       .datasource = $new
     else
      .
-    end 
+    end
+  elif type == "object" and has("current") then
+    if .current.text == $old and .current.value == $old then
+      .current.text = $new | .current.value = $new
+    else
+      .
+    end
   else
     .
   end


### PR DESCRIPTION
## Summary

Hello,
I used the template/variable feature and the data source names were saved.
- [Variables | Grafana Labs](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/)

This changes works for me.

## Environments

- Grafana 7.0.6
- jq 1.6
- Ubuntu 18.04 LTS on WSL1

## Steps to reproduce

Example dashboard: [templating-grafana7.0.6.zip](https://github.com/knoguchi/grafana-dash/files/5032480/templating-grafana7.0.6.zip)

```json
...
    "templating": {
      "list": [
        {
          "current": {
            "selected": true,
            "text": "CloudWatch(old)",
            "value": "CloudWatch(old)"
          },
...
```

Command:
```shell
jq -Mf ./update-datasource.jq --arg old "CloudWatch(old)" --arg new "CloudWatch(new)" < templating-grafana7.0.6.json | jq .dashboard.templating
```
